### PR TITLE
Split account and database functionality and minor improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 22.10.0
+    hooks:
+    - id: black
+      language_version: python3.10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://github.com/ambv/black
+-   repo: https://github.com/psf/black
     rev: 22.10.0
     hooks:
     - id: black

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # flask-boilerplate
 
 Quick-start  
-The following commands will start a container with the flask server running on port 5000:
+The following commands will start a container with the flask server running on port 3000:
 ```
 $ docker build . -t flask-boilerplate:latest
 $ docker-compose up
+```
+
+Or run it without Docker:
+```
+$ python install -r requirements
+$ python run.py
 ```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,15 +1,16 @@
 import secrets
 from flask import Flask
 from flask_bootstrap import Bootstrap5
-#from flask_sqlalchemy import SQLAlchemy
-#from flask_login import LoginManager
+
+# from flask_sqlalchemy import SQLAlchemy
+# from flask_login import LoginManager
 
 app = Flask(__name__)
 
 ## uncomment for account management
-#login_manager = LoginManager()
-#login_manager.login_view = "index"
-#login_manager.login_message = "Please login first."
+# login_manager = LoginManager()
+# login_manager.login_view = "index"
+# login_manager.login_message = "Please login first."
 
 with app.app_context():
     app.secret_key = secrets.token_urlsafe()
@@ -24,5 +25,5 @@ from app import views, api, errors
 ## uncomment for account management
 # from app import views_accounts, errors_accounts
 
-#with app.app_context():
+# with app.app_context():
 #    sqlalchemy.create_all()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,18 +1,29 @@
 import secrets
 from flask import Flask
-from flask_bootstrap import Bootstrap
-from flask_sqlalchemy import SQLAlchemy
-from flask_login import LoginManager
+from flask_bootstrap import Bootstrap5
+#from flask_sqlalchemy import SQLAlchemy
+#from flask_login import LoginManager
 
 app = Flask(__name__)
-app.secret_key = secrets.token_urlsafe()
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///data/sqlite.db'
 
-bootstrap = Bootstrap(app)
-sqlalchemy = SQLAlchemy(app)
-login_manager = LoginManager()
-login_manager.init_app(app)
-login_manager.login_view = "index"
-login_manager.login_message = "Please login first."
+## uncomment for account management
+#login_manager = LoginManager()
+#login_manager.login_view = "index"
+#login_manager.login_message = "Please login first."
+
+with app.app_context():
+    app.secret_key = secrets.token_urlsafe()
+
+## uncomment for database + account management
+#    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite+pysqlite:///sqlite.db'
+#    sqlalchemy = SQLAlchemy(app)
+#    bootstrap = Bootstrap5(app)
+#    login_manager.init_app(app)
 
 from app import views, api, errors
+
+## uncomment for account management
+# from app import views_accounts, errors_accounts
+
+#with app.app_context():
+#    sqlalchemy.create_all()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,11 +13,10 @@ app = Flask(__name__)
 
 with app.app_context():
     app.secret_key = secrets.token_urlsafe()
-
+    bootstrap = Bootstrap5(app)
 ## uncomment for database + account management
 #    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite+pysqlite:///sqlite.db'
 #    sqlalchemy = SQLAlchemy(app)
-#    bootstrap = Bootstrap5(app)
 #    login_manager.init_app(app)
 
 from app import views, api, errors

--- a/app/api.py
+++ b/app/api.py
@@ -9,7 +9,6 @@ def endpoints():
     return jsonify({'endpoints': endpoints})
 
 
-
 endpoints = [{"path": "/api/",
               "name": endpoints.__name__,
               "method": "GET",

--- a/app/api.py
+++ b/app/api.py
@@ -3,15 +3,17 @@ from flask import request, jsonify, abort
 from app import app
 
 
-@app.route("/api/", methods=['GET'])
+@app.route("/api/", methods=["GET"])
 def endpoints():
     """Overview of the API endpoints."""
-    return jsonify({'endpoints': endpoints})
+    return jsonify({"endpoints": endpoints})
 
 
-endpoints = [{"path": "/api/",
-              "name": endpoints.__name__,
-              "method": "GET",
-              "description": endpoints.__doc__},
-             ]
-
+endpoints = [
+    {
+        "path": "/api/",
+        "name": endpoints.__name__,
+        "method": "GET",
+        "description": endpoints.__doc__,
+    },
+]

--- a/app/errors.py
+++ b/app/errors.py
@@ -4,4 +4,4 @@ from app import app
 
 @app.errorhandler(404)
 def page_not_found(e):
-    return render_template('404.html'), 404
+    return render_template("404.html"), 404

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,12 +1,7 @@
 from flask import render_template
-from app import app, login_manager
+from app import app
 
 
 @app.errorhandler(404)
 def page_not_found(e):
     return render_template('404.html'), 404
-
-
-@login_manager.unauthorized_handler
-def unauthorized():
-    return render_template('index.html'), 401

--- a/app/errors_accounts.py
+++ b/app/errors_accounts.py
@@ -1,0 +1,7 @@
+from flask import render_template
+from app import app, login_manager
+
+
+@login_manager.unauthorized_handler
+def unauthorized():
+    return render_template('index.html'), 401

--- a/app/errors_accounts.py
+++ b/app/errors_accounts.py
@@ -4,4 +4,4 @@ from app import app, login_manager
 
 @login_manager.unauthorized_handler
 def unauthorized():
-    return render_template('index.html'), 401
+    return render_template("index.html"), 401

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -8,6 +8,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 https://flask-sqlalchemy.palletsprojects.com/en/2.x/quickstart/
 """
 
+
 class User(sa.Model, UserMixin):
     id = sa.Column(sa.Integer, primary_key=True)
     username = sa.Column(sa.String(80), unique=True, nullable=False)
@@ -23,10 +24,9 @@ class User(sa.Model, UserMixin):
         return check_password_hash(self.password_hash, password)
 
     def __repr__(self):
-        return '<User %r>' % self.username
+        return "<User %r>" % self.username
 
 
 @lm.user_loader
 def load_user(user_id):
     return User.query.get(int(user_id))
-

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -1,13 +1,12 @@
+import os
 from app import sqlalchemy as sa
 from app import login_manager as lm
 from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 
-
 """
 https://flask-sqlalchemy.palletsprojects.com/en/2.x/quickstart/
 """
-
 
 class User(sa.Model, UserMixin):
     id = sa.Column(sa.Integer, primary_key=True)
@@ -31,4 +30,3 @@ class User(sa.Model, UserMixin):
 def load_user(user_id):
     return User.query.get(int(user_id))
 
-sa.create_all()

--- a/app/models/forms.py
+++ b/app/models/forms.py
@@ -3,13 +3,13 @@ from wtforms import StringField, PasswordField, SubmitField
 
 
 class LoginForm(FlaskForm):
-    username = StringField('Username')
-    password = PasswordField('Password')
-    submit = SubmitField('Submit')
+    username = StringField("Username")
+    password = PasswordField("Password")
+    submit = SubmitField("Submit")
 
 
 class RegisterForm(FlaskForm):
-    username = StringField('Username')
-    password = PasswordField('Password')
-    confirm_password = PasswordField('Confirm password')
-    submit = SubmitField('Submit')
+    username = StringField("Username")
+    password = PasswordField("Password")
+    confirm_password = PasswordField("Confirm password")
+    submit = SubmitField("Submit")

--- a/app/views.py
+++ b/app/views.py
@@ -1,7 +1,7 @@
 from flask import render_template, redirect, request, flash, url_for
 from app import app
 
-@app.route("/", methods=['GET', 'POST'])
+
+@app.route("/", methods=["GET", "POST"])
 def index():
     return render_template("index.html")
-

--- a/app/views.py
+++ b/app/views.py
@@ -1,61 +1,7 @@
 from flask import render_template, redirect, request, flash, url_for
-from flask_login import login_required, login_user, logout_user
-from sqlalchemy.orm.exc import NoResultFound
-from app.models import database, forms
-from app import app, sqlalchemy
-
+from app import app
 
 @app.route("/", methods=['GET', 'POST'])
 def index():
     return render_template("index.html")
 
-
-@app.route('/login', methods=['GET', 'POST'])
-def login():
-    login_form = forms.LoginForm()
-    if login_form.validate_on_submit():
-        username = request.form['username']
-        password = request.form['password']
-        query = database.User.query.filter_by(username=username)
-
-        try:
-            user = query.one()
-            if not user.check_password(password):
-                flash("Wrong password")
-                return render_template('index.html', form=login_form)
-        except NoResultFound:
-            flash("User not found")
-            return redirect(url_for('register'))
-
-        login_user(user)
-        flash('Logged in successfully.')
-        next = request.args.get('next')
-        # if not is_safe_url(next):  # todo
-        #     return flask.abort(400)
-        return redirect(next or url_for('index'))
-    else:
-        print("not valid")
-    return render_template('login.html', form=login_form)
-
-
-@app.route('/register', methods=['GET', 'POST'])
-def register():
-    register_form = forms.RegisterForm()
-    if register_form.validate_on_submit():
-        username = request.form['username']
-        password = request.form['password']
-        user = database.User(username=username)
-        user.set_password(password)
-        sqlalchemy.session.add(user)
-        sqlalchemy.session.commit()
-        flash("Created account")
-        return redirect(url_for('login'))
-    return render_template('register.html', form=register_form)
-
-
-@app.route("/logout")
-@login_required
-def logout():
-    logout_user()
-    flash("You have logged out")
-    return redirect(url_for("index"))

--- a/app/views_accounts.py
+++ b/app/views_accounts.py
@@ -1,0 +1,55 @@
+from flask import render_template, redirect, request, flash, url_for
+from flask_login import login_required, login_user, logout_user
+from sqlalchemy.orm.exc import NoResultFound
+from app.models import database, forms
+from app import app, sqlalchemy
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    login_form = forms.LoginForm()
+    if login_form.validate_on_submit():
+        username = request.form['username']
+        password = request.form['password']
+        query = database.User.query.filter_by(username=username)
+
+        try:
+            user = query.one()
+            if not user.check_password(password):
+                flash("Wrong password")
+                return render_template('index.html', form=login_form)
+        except NoResultFound:
+            flash("User not found")
+            return redirect(url_for('register'))
+
+        login_user(user)
+        flash('Logged in successfully.')
+        next = request.args.get('next')
+        # if not is_safe_url(next):  # todo
+        #     return flask.abort(400)
+        return redirect(next or url_for('index'))
+    else:
+        print("not valid")
+    return render_template('login.html', form=login_form)
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    register_form = forms.RegisterForm()
+    if register_form.validate_on_submit():
+        username = request.form['username']
+        password = request.form['password']
+        user = database.User(username=username)
+        user.set_password(password)
+        sqlalchemy.session.add(user)
+        sqlalchemy.session.commit()
+        flash("Created account")
+        return redirect(url_for('login'))
+    return render_template('register.html', form=register_form)
+
+
+@app.route("/logout")
+@login_required
+def logout():
+    logout_user()
+    flash("You have logged out")
+    return redirect(url_for("index"))

--- a/app/views_accounts.py
+++ b/app/views_accounts.py
@@ -4,47 +4,48 @@ from sqlalchemy.orm.exc import NoResultFound
 from app.models import database, forms
 from app import app, sqlalchemy
 
-@app.route('/login', methods=['GET', 'POST'])
+
+@app.route("/login", methods=["GET", "POST"])
 def login():
     login_form = forms.LoginForm()
     if login_form.validate_on_submit():
-        username = request.form['username']
-        password = request.form['password']
+        username = request.form["username"]
+        password = request.form["password"]
         query = database.User.query.filter_by(username=username)
 
         try:
             user = query.one()
             if not user.check_password(password):
                 flash("Wrong password")
-                return render_template('index.html', form=login_form)
+                return render_template("index.html", form=login_form)
         except NoResultFound:
             flash("User not found")
-            return redirect(url_for('register'))
+            return redirect(url_for("register"))
 
         login_user(user)
-        flash('Logged in successfully.')
-        next = request.args.get('next')
+        flash("Logged in successfully.")
+        next = request.args.get("next")
         # if not is_safe_url(next):  # todo
         #     return flask.abort(400)
-        return redirect(next or url_for('index'))
+        return redirect(next or url_for("index"))
     else:
         print("not valid")
-    return render_template('login.html', form=login_form)
+    return render_template("login.html", form=login_form)
 
 
-@app.route('/register', methods=['GET', 'POST'])
+@app.route("/register", methods=["GET", "POST"])
 def register():
     register_form = forms.RegisterForm()
     if register_form.validate_on_submit():
-        username = request.form['username']
-        password = request.form['password']
+        username = request.form["username"]
+        password = request.form["password"]
         user = database.User(username=username)
         user.set_password(password)
         sqlalchemy.session.add(user)
         sqlalchemy.session.commit()
         flash("Created account")
-        return redirect(url_for('login'))
-    return render_template('register.html', form=register_form)
+        return redirect(url_for("login"))
+    return render_template("register.html", form=register_form)
 
 
 @app.route("/logout")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
      volumes:
        - ./app:/app
      ports:
-       - 5000:5000
+       - 3000:3000
 #     networks:
 #       - traefik_proxy
 #     labels:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+Bootstrap-Flask==2.1.0
+Flask==2.2.2
+Flask-Login==0.6.2
+Flask-SQLAlchemy==3.0.0
+SQLAlchemy==1.4.41
+Flask-WTF==1.0.1
+WTForms==3.0.1
+
+# dev
+pre-commit==2.20.0
+black==22.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-Flask==1.1.1
-Bootstrap-Flask==1.7.0
-Flask-Login==0.5.0
-Flask-SQLAlchemy==2.5.1
-WTForms==2.3.3
+Bootstrap-Flask==2.1.0
+Flask==2.2.2
+Flask-Login==0.6.2
+Flask-SQLAlchemy==3.0.0
+SQLAlchemy==1.4.41
+Flask-WTF==1.0.1
+WTForms==3.0.1

--- a/run.py
+++ b/run.py
@@ -2,4 +2,4 @@
 from app import app
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', debug=False)
+    app.run(host='0.0.0.0', port=3000, debug=False)

--- a/run.py
+++ b/run.py
@@ -2,4 +2,4 @@
 from app import app
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=3000, debug=False)
+    app.run(host="0.0.0.0", port=3000, debug=False)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,6 +12,6 @@ def test_home_page():
 
     # Create a test client using the Flask application configured for testing
     with app.test_client() as test_client:
-        response = test_client.get('/')
+        response = test_client.get("/")
         assert response.status_code == 200
         assert b"html" in response.data


### PR DESCRIPTION
Since many projects don't necessarily need account management, or maybe not even a database, the Flask-Login and Flask-SQLAlchemy have been moved to their own files and are now optional.
The functionality is commented out by default, but can be easily reinstated by uncommenting a few lines in `app/__init__.py`.

This PR updates all dependencies to their latest version, including the latest version of Flask and Bootstrap 5.

The default port number 5000 is often already taken, so I changed it to 3000.

Additionally this PR adds [Black](https://github.com/psf/black) formatting and Black pre-commit configuration.